### PR TITLE
add net46

### DIFF
--- a/Dadata.Test/Dadata.Test.csproj
+++ b/Dadata.Test/Dadata.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFrameworks>netcoreapp2.1;net46</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />

--- a/Dadata/Dadata.csproj
+++ b/Dadata/Dadata.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net46;</TargetFrameworks>
         <Version>21.9.1</Version>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+        <PackageReference Include="System.Net.Http" Version="4.3.3"/>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
We have a project compatible with both versions of the framework and we need DaData api client in our solution. When we adding dadata client via api, we got an error:
`Package Dadata 21.12.0 is not compatible with net46 (.NETFramework,Version=v4.6). Package Dadata 21.12.0 supports: netstandard2.0 (.NETStandard,Version=v2.0) `
I think it will be useful for other teams in a similar situation