### PR TITLE
Update Party.cs

### DIFF
--- a/Dadata/Model/Party.cs
+++ b/Dadata/Model/Party.cs
@@ -91,8 +91,8 @@ namespace Dadata.Model
 
     public class PartyCitizenship
     {
-        public PartyNameUnit code { get; set; }
-        public PartyCodeUnit name { get; set; }
+        public PartyCodeUnit code { get; set; }
+        public PartyNameUnit name { get; set; }
     }
 
     public class PartyCodeUnit


### PR DESCRIPTION
In class PartyCitizenship, property "code" has type  PartyNameUnit (and "name" has type PartyCodeUnit) . It is mistake, because json citizeship data cannot be parsed correctly.